### PR TITLE
feat: load terrain from static image

### DIFF
--- a/src/views/map-result-bp.tsx
+++ b/src/views/map-result-bp.tsx
@@ -272,8 +272,9 @@ export default function MapResultBP({ geo }: MapResultProps) {
             offset: -32768,
         },
         // Digital elevation model from https://www.usgs.gov/
-        elevationData: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
-        texture: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+        elevationData: 'SU84nw_elevation.png',
+        color: [255,255,255],
+        bounds: [-0.8552938788056027, 51.197904494098374, -0.7848639958949948, 51.24357599144819]
       });
         setLayers([ground, storey, exif3dCameraLayer, deckglMarkerLayer, deckglTerrainLayer])    
     }

--- a/src/views/map-result-bp.tsx
+++ b/src/views/map-result-bp.tsx
@@ -272,7 +272,7 @@ export default function MapResultBP({ geo }: MapResultProps) {
             offset: -32768,
         },
         // Digital elevation model from https://www.usgs.gov/
-        elevationData: 'SU84nw_elevation.png',
+        elevationData: 'SU84nw_DTM_1m.png',
         color: [255,255,255],
         bounds: [-0.8552938788056027, 51.197904494098374, -0.7848639958949948, 51.24357599144819]
       });

--- a/src/views/map-result-bp.tsx
+++ b/src/views/map-result-bp.tsx
@@ -262,16 +262,19 @@ export default function MapResultBP({ geo }: MapResultProps) {
                                             onClick: onClick,
                                           })
   
-  const deckglTerrainLayer = new TerrainLayer({
-    elevationDecoder: {
-      "rScaler": 6553.6,
-      "gScaler": 25.6,
-      "bScaler": 0.1,
-      "offset": -10000
-    },
-                                            // Digital elevation model from https://www.usgs.gov/
-                                            elevationData: api_url+'/data/su_/{z}/{x}/{y}.png',
-                                          });
+      const deckglTerrainLayer = new TerrainLayer({
+        id: "terrain",
+        maxZoom: 15,
+        elevationDecoder: {
+            rScaler: 256,
+            gScaler: 1,
+            bScaler: 1 / 256,
+            offset: -32768,
+        },
+        // Digital elevation model from https://www.usgs.gov/
+        elevationData: 'https://s3.amazonaws.com/elevation-tiles-prod/terrarium/{z}/{x}/{y}.png',
+        texture: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      });
         setLayers([ground, storey, exif3dCameraLayer, deckglMarkerLayer, deckglTerrainLayer])    
     }
   
@@ -418,7 +421,7 @@ export default function MapResultBP({ geo }: MapResultProps) {
               controller={true}
             >
 
-              <Map mapboxAccessToken={mapboxgl.accessToken} mapStyle="mapbox://styles/mapbox/streets-v9" />
+              {/* <Map mapboxAccessToken={mapboxgl.accessToken} mapStyle="mapbox://styles/mapbox/streets-v9" /> */}
             </DeckGL>
           </Container>
         </Box>


### PR DESCRIPTION
The static image is converted from SU84nw_FZ_DSM_1m.tif to "terrarium" elevation format (PNG).
<img width="900" alt="image" src="https://github.com/buildvoc/mapbox-gl_deck.gl_turf.js-ts/assets/18549629/adb03f81-4232-48d2-8e43-a57344238f48">
<img width="802" alt="image" src="https://github.com/buildvoc/mapbox-gl_deck.gl_turf.js-ts/assets/18549629/7b0badad-0119-4195-9977-b745cdbba881">

